### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,10 @@
 [![Build Status](https://travis-ci.org/ckan/losser.svg)](https://travis-ci.org/ckan/losser)
 [![Coverage Status](https://img.shields.io/coveralls/ckan/losser.svg)](https://coveralls.io/r/ckan/losser)
-[![Latest Version](https://pypip.in/version/losser/badge.svg)](https://pypi.python.org/pypi/losser/)
-[![Downloads](https://pypip.in/download/losser/badge.svg)](https://pypi.python.org/pypi/losser/)
-[![Supported Python versions](https://pypip.in/py_versions/losser/badge.svg)](https://pypi.python.org/pypi/losser/)
-[![Development Status](https://pypip.in/status/losser/badge.svg)](https://pypi.python.org/pypi/losser/)
-[![License](https://pypip.in/license/losser/badge.svg)](https://pypi.python.org/pypi/losser/)
+[![Latest Version](https://img.shields.io/pypi/v/losser.svg)](https://pypi.python.org/pypi/losser/)
+[![Downloads](https://img.shields.io/pypi/dm/losser.svg)](https://pypi.python.org/pypi/losser/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/losser.svg)](https://pypi.python.org/pypi/losser/)
+[![Development Status](https://img.shields.io/pypi/status/losser.svg)](https://pypi.python.org/pypi/losser/)
+[![License](https://img.shields.io/pypi/l/losser.svg)](https://pypi.python.org/pypi/losser/)
 
 
 Losser


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20losser))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `losser`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.