### PR TITLE
Support python 3 (in a breaking way)

### DIFF
--- a/losser/cli.py
+++ b/losser/cli.py
@@ -1,11 +1,10 @@
 """The command-line interface for losser."""
-from __future__ import absolute_import
+
 
 import argparse
 import collections
 import json
 import sys
-import StringIO
 
 import losser.losser as losser
 
@@ -255,7 +254,7 @@ def parse(parser=None, args=None):
         columns = collections.OrderedDict()
         parsed_args.columns = columns
 
-    for title, spec in columns.items():
+    for title, spec in list(columns.items()):
         if "pattern" not in spec:
             raise ColumnWithoutPatternError(
                 'Column "{0}" needs a pattern'.format(title))

--- a/losser/test_cli.py
+++ b/losser/test_cli.py
@@ -1,5 +1,5 @@
 """Tests for the command-line argument parsing."""
-from __future__ import absolute_import
+
 
 import collections
 import inspect
@@ -151,7 +151,7 @@ def test_with_one_column_argument():
         in_=mock_stdin)
 
     table_function.assert_called_once_with(
-        u"foobar",
+        "foobar",
         collections.OrderedDict(Title={"pattern": "^title$"}),
         csv=True, pretty=False)
 
@@ -336,7 +336,7 @@ def test_max_length():
         in_=mock_stdin)
 
     table_function.assert_called_once_with(
-        u"foobar",
+        "foobar",
         collections.OrderedDict(
             Title={"pattern": "^title$", "max_length": 255}),
         csv=True, pretty=False)
@@ -389,7 +389,7 @@ def test_pattern_with_multiple_arguments():
         in_=mock_stdin)
 
     table_function.assert_called_once_with(
-        u"foobar",
+        "foobar",
         collections.OrderedDict(
             Formats={"pattern": ["^resources$", "^format$"]}),
         csv=True, pretty=False)

--- a/losser/test_losser.py
+++ b/losser/test_losser.py
@@ -5,7 +5,7 @@ import inspect
 
 import nose.tools
 
-import losser
+from . import losser
 
 
 def test_number():
@@ -39,9 +39,9 @@ def test_string_with_strip_and_transform():
 
 def test_unicode_string():
     string_transformations = [lambda x: x[:3]]
-    result = losser.query([], u" fübar  ", strip=True,
+    result = losser.query([], " fübar  ", strip=True,
                             string_transformations=string_transformations)
-    assert result == u"füb"
+    assert result == "füb"
 
 
 def test_boolean():
@@ -468,7 +468,6 @@ def test_returning_csv():
     columns["Formats"] = dict(pattern_path=["^resources$", "^format$"])
 
     csv_string = losser.table(rows, columns, csv=True)
-
     assert csv_string == (
         "Author,Formats\r\n"
         'Guybrush Threepwood,"CSV, JSON"\r\n'
@@ -511,12 +510,11 @@ def test_returning_multiple_matches_as_extra_columns():
                              return_multiple_columns=True)
 
     csv_string = losser.table(rows, columns, csv=True)
-
     nose.tools.assert_equals(csv_string,
-        'Author,extras_second,extras_first\r\n'
-        'Guybrush Threepwood,second extra,first extra\r\n'
-        'LeChuck,second extra,first extra\r\n'
-        'Herman Toothrot,second extra,first extra\r\n'
+        'Author,extras_first,extras_second\r\n'
+        'Guybrush Threepwood,first extra,second extra\r\n'
+        'LeChuck,first extra,second extra\r\n'
+        'Herman Toothrot,first extra,second extra\r\n'
     )
 
 
@@ -581,8 +579,8 @@ def test_returning_multiple_matches_matching_multiple_dicts():
     csv_string = losser.table(rows, columns, csv=True)
 
     nose.tools.assert_equals(csv_string,
-        'Author,extra_second,extra_first,extras_fourth,extras_third\r\n'
-        'Guybrush,second extra,first extra,second extra,first extra\r\n'
+        'Author,extra_first,extra_second,extras_third,extras_fourth\r\n'
+        'Guybrush,first extra,second extra,first extra,second extra\r\n'
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6.8',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
Context:
I wanted to use https://github.com/ckan/ckanapi-exporter in python 3, and this project is a dependency.

Here is my quick attempt at updating this project to support python 3.

The tests pass, although I did change the column ordering of the test output, unsure if this is a breaking issue or not.